### PR TITLE
Bit bang mode

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -11,6 +11,12 @@ To install this library, unzip it into the "libraries" directory of your
 Arduino sketchbook folder. If there is not already a folder named "libraries"
 then create it. 
 
+You will need to modify TCL.h to choose between bit-bang mode on 2 digital
+IO pins or if you want SPI mode by uncommenting ONE AND ONLY ONE of the
+#define statements for TCL_DIO or TCL_SPI. If you select TCL_DIO, you should
+also modify the #defines for TCL_CLOCKPIN and TCL_DATAPIN to select the pins
+that you will use for Clock and Data, respectively.
+
 Hardware
 --------
 The Total Control Lighting strands use 4 wires to provide both power and
@@ -20,6 +26,14 @@ designated with the following colors.
 Red:    +5V
 Yellow: Clock
 Green:  Data
+Blue:   Ground
+
+If you're cutting and connecting individual LEDs, the color coding is
+somewhat different, with the following mappings:
+
+Red:    +5V
+Green:  Clock
+White:  Data
 Blue:   Ground
 
 If you are using a small number of LEDs the Arduino itself can provide power

--- a/TCL.cpp
+++ b/TCL.cpp
@@ -10,12 +10,30 @@
 
 TclClass TCL;
 
+#ifdef TCL_DIO
+uint8_t TclClass::datapinmask, TclClass::clkpinmask;
+volatile uint8_t *TclClass::dataport, *TclClass::clkport;
+#endif
+
+
 void TclClass::begin() {
+#ifdef TCL_SPI
   // Set the SPI parameters
   SPI.begin();
   SPI.setBitOrder(MSBFIRST);
   SPI.setDataMode(SPI_MODE0);
   SPI.setClockDivider(SPI_CLOCK_DIV2);
+#endif
+#ifdef TCL_DIO
+  pinMode(TCL_CLOCKPIN, OUTPUT);
+  pinMode(TCL_DATAPIN, OUTPUT);
+  clkport     = portOutputRegister(digitalPinToPort(TCL_CLOCKPIN));
+  clkpinmask  = digitalPinToBitMask(TCL_CLOCKPIN);
+  dataport    = portOutputRegister(digitalPinToPort(TCL_DATAPIN));
+  datapinmask = digitalPinToBitMask(TCL_DATAPIN);
+  *clkport   &= ~clkpinmask;
+  *dataport  &= ~datapinmask;
+#endif
 }
 
 void TclClass::setupDeveloperShield() {
@@ -23,7 +41,7 @@ void TclClass::setupDeveloperShield() {
   pinMode(TCL_MOMENTARY2, INPUT);
   pinMode(TCL_SWITCH1, INPUT);
   pinMode(TCL_SWITCH2, INPUT);
-
+  
   digitalWrite(TCL_MOMENTARY1, HIGH);
   digitalWrite(TCL_MOMENTARY2, HIGH);
   digitalWrite(TCL_SWITCH1, HIGH);
@@ -31,7 +49,9 @@ void TclClass::setupDeveloperShield() {
 }
 
 void TclClass::end() {
+#ifdef TCL_SPI
   SPI.end();
+#endif
 }
 
 byte TclClass::makeFlag(byte red, byte green, byte blue) {
@@ -43,11 +63,34 @@ byte TclClass::makeFlag(byte red, byte green, byte blue) {
   return ~flag;
 }
 
+#ifdef TCL_DIO
+void TclClass::dioWrite(byte c) {
+  for(byte bit = 0x80; bit; bit >>= 1) {
+    if(c & bit) {
+      *dataport |=  datapinmask;
+    } else {
+      *dataport &= ~datapinmask;
+    }
+    *clkport |=  clkpinmask;
+    *clkport &= ~clkpinmask;
+  }
+
+}
+#endif
+
 void TclClass::sendFrame(byte flag, byte red, byte green, byte blue) {
+#ifdef TCL_SPI
   SPI.transfer(flag);
   SPI.transfer(blue);
   SPI.transfer(green);
   SPI.transfer(red);
+#endif
+#ifdef TCL_DIO
+  dioWrite(flag);
+  dioWrite(blue);
+  dioWrite(green);
+  dioWrite(red);
+#endif
 }
 
 void TclClass::sendColor(byte red, byte green, byte blue) {
@@ -62,3 +105,10 @@ void TclClass::sendEmptyFrame() {
   sendFrame(0x00,0x00,0x00,0x00);
 }
 
+void TclClass::setAll(int num_leds, byte red, byte green, byte blue) {
+  sendEmptyFrame();
+  for (int i=0; i<num_leds; i++) {
+    sendColor(red, green, blue);
+  }
+  sendEmptyFrame();
+}

--- a/TCL.h
+++ b/TCL.h
@@ -5,6 +5,11 @@
  * This program is distributed under the Artistic License 2.0, a copy of which
  * is included in the file LICENSE.txt
  ****************************************************************************/
+// Choose between bit bang (any 2 dio pins) and SPI modes
+
+#define TCL_DIO
+//#define TCL_SPI
+
 #ifndef TCL_h
 #define TCL_h
 #if defined(ARDUINO) && ARDUINO >= 100
@@ -12,7 +17,10 @@
 #else
 #include "WProgram.h"
 #endif
+
+#ifdef TCL_SPI
 #include "SPI.h"
+#endif
 
 #define TCL_POT1 A0
 #define TCL_POT2 A1
@@ -23,6 +31,11 @@
 #define TCL_SWITCH1 6
 #define TCL_SWITCH2 7
 
+#ifdef TCL_DIO
+#define TCL_CLOCKPIN 0
+#define TCL_DATAPIN 1
+#endif
+
 class TclClass {
   public:
     static void begin();
@@ -32,6 +45,13 @@ class TclClass {
     static void sendColor(byte red, byte green, byte blue);
     static void sendEmptyFrame();
     static byte makeFlag(byte red, byte green, byte blue);
+    static void setAll(int num_leds, byte red, byte green, byte blue);
+  private:
+#ifdef TCL_DIO
+    static byte datapinmask, clkpinmask;
+    static volatile byte *dataport, *clkport;
+    static void dioWrite(uint8_t c);
+#endif
 };
 
 extern TclClass TCL;


### PR DESCRIPTION
Hey Chris, I've made additions to support bit-bang mode on any 2 arbitrary digital output pins.

It's currently controlled entirely through #defines and #ifdefs, which minimizes compiled code size but is kind of inelegant as a library since the end-user would need to actually modify the library to configure the system.

Alternatively, I could change begin() to take a bunch of arguments or overload it with an version that takes arguments. Although then there is a question of what the no-arg begin() should default to, since right now you could take an existing example and run it in bit-bang mode with no modifications to the code.

If you have a preference, let me know and I can alter the interface to match.
